### PR TITLE
added cache for the struct reflection, removed need for errors packag…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 go:
  - 1.5
- - 1.6
+ - 1.8
+ - 1.9
  - tip
 
 script:

--- a/builtin.go
+++ b/builtin.go
@@ -74,6 +74,27 @@ func required(v interface{}, params []string) error {
 	return nil
 }
 
+func notEmpty(i interface{}, params []string) error {
+	switch v := i.(type) {
+	case fmt.Stringer:
+		if len(v.String()) <= 0 {
+			return ErrEmpty
+		}
+	case *string:
+		if v == nil || len(*v) <= 0 {
+			return ErrEmpty
+		}
+	case string:
+		if len(v) <= 0 {
+			return ErrEmpty
+		}
+	default:
+		return ErrUnsupported
+	}
+
+	return nil
+}
+
 // length tests whether a variable's length is equal to a given
 // value. For strings it tests the number of characters whereas
 // for maps and slices it tests the number of items.

--- a/builtin.go
+++ b/builtin.go
@@ -681,6 +681,33 @@ func base64(v interface{}, params []string) error {
 	return nil
 }
 
+func enum(v interface{}, params []string) error {
+
+	checkEnum := func(a string) bool {
+		for _, b := range params {
+			if b == a {
+				return true
+			}
+		}
+		return false
+	}
+
+	if ss, ok := v.([]string); ok {
+		for _, s := range ss {
+			if checkEnum(s) == false {
+				return ErrEnum
+			}
+		}
+	} else if s, ok := v.(string); ok {
+		if checkEnum(s) == false {
+			return ErrEnum
+		}
+	} else {
+		return ErrUnsupported
+	}
+	return nil
+}
+
 // asInt returns the parameter as a int64
 // or panics if it can't convert
 func asInt(param string) (int64, error) {

--- a/builtin_test.go
+++ b/builtin_test.go
@@ -727,3 +727,16 @@ func (s *BuiltinSuite) TestExclude(c *C) {
 	c.Check(validate.Valid(string(""), "exclude(foo,bar)"), IsNil)
 	c.Check(validate.Valid(string("baz"), "exclude(foo,bar)"), IsNil)
 }
+
+func (s *BuiltinSuite) TestEnum(c *C) {
+	c.Check(validate.Valid(string(""), "enum(aa,bb,cc)"), ErrorMatches, "invalid value")
+	c.Check(validate.Valid(string("test.com"), "enum(aa,bb,cc)"), ErrorMatches, "invalid value")
+	c.Check(validate.Valid([]string{""}, "enum(aa,bb,cc)"), ErrorMatches, "invalid value")
+	c.Check(validate.Valid([]string{"test.com"}, "enum(aa,bb,cc)"), ErrorMatches, "invalid value")
+	c.Check(validate.Valid(int(0), "enum(aa,bb,cc)"), ErrorMatches, "unsupported type")
+
+
+	c.Check(validate.Valid(string("bb"), "enum(aa,bb,cc)"), IsNil)
+	c.Check(validate.Valid([]string{"bb","aa"}, "enum(aa,bb,cc)"), IsNil)
+	c.Check(validate.Valid([]string{}, "enum(aa,bb,cc)"), IsNil)
+}

--- a/errors.go
+++ b/errors.go
@@ -148,6 +148,9 @@ var (
 
 	// ErrBase64 is the error returned when value is not a valid base64 encoded
 	ErrBase64 = NewValidationError("invalid base64 encoded")
+
+	// ErrBEnum is the error returned when value is not in a set of enum values
+	ErrEnum = NewValidationError("invalid value")
 )
 
 type ErrorList []error

--- a/errors.go
+++ b/errors.go
@@ -1,118 +1,275 @@
 package validate
 
 import (
-	"github.com/mbict/go-errors"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
 )
+
+type ValidationError error
+
+type validationError struct {
+	template string
+	args     []interface{}
+}
+
+func (e validationError) Template() string {
+	return e.template
+}
+
+func (e validationError) Args() []interface{} {
+	return e.args
+}
+
+func (e validationError) Error() string {
+	return fmt.Sprintf(e.template, e.args...)
+}
+
+func NewValidationError(template string, args ...interface{}) ValidationError {
+	return &validationError{
+		template: template,
+		args:     args,
+	}
+}
 
 var (
 	// errOmitEmpty is the error returned when variable has a empty value
-	errOmitEmpty = errors.New("omitempty")
+	errOmitEmpty = NewValidationError("omitempty")
 
 	// ErrRequired is the error returned when variable has a empty value
-	ErrRequired = errors.New("required")
+	ErrRequired = NewValidationError("required")
+
+	// ErrEmpty is the error returned when variable has a empty value
+	ErrEmpty = NewValidationError("value is empty")
 
 	// ErrMin is the error returned when variable is less than mininum
 	// value specified
-	ErrMin = errors.New("less than min")
+	ErrMin = NewValidationError("less than min")
 
 	// ErrMax is the error returned when variable is more than
 	// maximum specified
-	ErrMax = errors.New("greater than max")
+	ErrMax = NewValidationError("greater than max")
 
 	// ErrLen is the error returned when length is not equal to
 	// param specified
-	ErrLen = errors.New("invalid length")
+	ErrLen = NewValidationError("invalid length")
 
 	// ErrBetween is the error returned when variable is less than
 	// minimum or more than maximum specified
-	ErrBetween = errors.New("not between")
+	ErrBetween = NewValidationError("not between")
 
 	// ErrAround is the error returned when variable is more than
 	// minimum and less then maximum specified
-	ErrAround = errors.New("not around")
+	ErrAround = NewValidationError("not around")
 
 	// ErrRegexp is the error returned when the value does not
 	// match the provided regular expression parameter
-	ErrRegexp = errors.New("regular expression mismatch")
+	ErrRegexp = NewValidationError("regular expression mismatch")
 
 	// ErrIdentifier is the error returned when the value does not match the
 	// identifier pattern
-	ErrIdentifier = errors.New("invalid id format")
+	ErrIdentifier = NewValidationError("invalid id format")
 
 	// ErrAlpha is the error returned when the value does contains
 	// other characters than alphas
-	ErrAlpha = errors.New("alpha dash mismatch")
+	ErrAlpha = NewValidationError("alpha dash mismatch")
 
 	// ErrAlphaNumeric is the error returned when the value does contains
 	// other characters than alphas or numerics
-	ErrAlphaNumeric = errors.New("alpha dash mismatch")
+	ErrAlphaNumeric = NewValidationError("alpha dash mismatch")
 
 	// ErrAlphaDash is the error returned when the value does contains
 	// other characters than alphas or dashes
-	ErrAlphaDash = errors.New("alpha dash mismatch")
+	ErrAlphaDash = NewValidationError("alpha dash mismatch")
 
 	// ErrAlphaDashDot is the error returned when the value does contains
 	// other characters than alpha's, dashes or dots
-	ErrAlphaDashDot = errors.New("alpha dash dot mismatch")
+	ErrAlphaDashDot = NewValidationError("alpha dash dot mismatch")
 
 	// ErrEmail is the error returned when the value does not match
 	// a valid email pattern
-	ErrEmail = errors.New("invalid email")
+	ErrEmail = NewValidationError("invalid email")
 
 	// ErrURL is the error returned when the value does not match
 	// a valid url pattern
-	ErrURL = errors.New("invalid url")
+	ErrURL = NewValidationError("invalid url")
 
 	// ErrInclude is the error returned when the value is not found
 	// in the set values that in the include list
-	ErrInclude = errors.New("value not found in set")
+	ErrInclude = NewValidationError("value not found in set")
 
 	// ErrExclude is the error returned when the value is  found
 	// in the set values to exclude
-	ErrExclude = errors.New("value matches one exluded value")
+	ErrExclude = NewValidationError("value matches one exluded value")
 
 	// ErrUnsupported is the error error returned when a validation rule
 	// is used with an unsupported variable type
-	ErrUnsupported = errors.New("unsupported type")
+	ErrUnsupported = NewValidationError("unsupported type")
 
 	// ErrBadParameter is the error returned when an invalid parameter
 	// is provided to a validation rule (e.g. a string where an int was
 	// expected (max(foo),len=(bar))
-	ErrBadParameter = errors.New("bad parameter")
+	ErrBadParameter = NewValidationError("bad parameter")
 
 	// ErrInvalidParameterCount is the error returned when there are not enough or
 	// to many parameters provided to the validation rule.
-	ErrInvalidParameterCount = errors.New("invalid parameter count")
+	ErrInvalidParameterCount = NewValidationError("invalid parameter count")
 
 	// ErrSyntax is the error who is returned when a invalid syntax is detected
-	// while parsing the structure tag
-	ErrSyntax = errors.New("syntax error")
+	// while parsing the structure validatorTag
+	ErrSyntax = NewValidationError("syntax error")
 
-	// ErrUnknownTag is the error returned when an unknown tag is found
-	ErrUnknownTag = errors.New("unknown tag")
+	// ErrUnknownTag is the error returned when an unknown validatorTag is found
+	ErrUnknownTag = NewValidationError("unknown validatorTag")
 
 	// ErrInvalid is the error returned when variable is invalid
 	// (normally a nil pointer)
-	ErrInvalid = errors.New("invalid value")
+	ErrInvalid = NewValidationError("invalid value")
 
 	// ErrNumber is the error returned when value is not a number
-	ErrNumber = errors.New("value not a number")
+	ErrNumber = NewValidationError("value not a number")
 
 	// ErrNumeric is the error returned when value is not in numeric format
-	ErrNumeric = errors.New("value not numeric")
+	ErrNumeric = NewValidationError("value not numeric")
 
 	// ErrUUID is the error returned when value is not in UUID format
-	ErrUUID = errors.New("invalid UUID")
+	ErrUUID = NewValidationError("invalid UUID")
 
 	// ErrUUID3 is the error returned when value is not in UUID format
-	ErrUUID3 = errors.New("invalid UUID3")
+	ErrUUID3 = NewValidationError("invalid UUID3")
 
 	// ErrUUID4 is the error returned when value is not in UUID format
-	ErrUUID4 = errors.New("invalid UUID4")
+	ErrUUID4 = NewValidationError("invalid UUID4")
 
 	// ErrUUID5 is the error returned when value is not in UUID format
-	ErrUUID5 = errors.New("invalid UUID5")
+	ErrUUID5 = NewValidationError("invalid UUID5")
 
 	// ErrBase64 is the error returned when value is not a valid base64 encoded
-	ErrBase64 = errors.New("invalid base64 encoded")
+	ErrBase64 = NewValidationError("invalid base64 encoded")
 )
+
+type ErrorList []error
+
+func (e ErrorList) Error() string {
+	errs := make([]string, len(e))
+	for i, err := range e {
+		errs[i] = err.Error()
+	}
+	return strings.Join(errs, ", ")
+}
+
+func (e ErrorList) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte('[')
+
+	//stringify errors
+	for i, es := range e {
+		if i != 0 {
+			buf.WriteByte(',')
+		}
+		val, err := json.Marshal(es.Error())
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(val)
+	}
+	buf.WriteByte(']')
+
+	return buf.Bytes(), nil
+}
+
+type Errors map[string][]error
+
+func (e Errors) Error() string {
+	names := make([]string, 0, len(e))
+	for name := range e {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	stringErrors := make([]string, len(e))
+	for ei, name := range names {
+		errs := make([]string, len(e[name]))
+		for ie, err := range e[name] {
+			errs[ie] = err.Error()
+		}
+		stringErrors[ei] = fmt.Sprintf("%s: [%s]", name, strings.Join(errs, ", "))
+	}
+	return strings.Join(stringErrors, ", ")
+}
+
+func (e *Errors) Add(field string, errors ...error) {
+	if *e == nil {
+		*e = make(Errors, 1)
+	}
+
+	(*e)[field] = append((*e)[field], errors...)
+}
+
+func (e *Errors) Merge(errors error) {
+	switch verr := errors.(type) {
+	case Errors:
+		for field, errs := range verr {
+			e.Add(field, errs...)
+		}
+	default:
+		e.Add("_", errors)
+	}
+}
+
+func (e *Errors) MergePrefix(prefix string, errors error) {
+	switch verr := errors.(type) {
+	case Errors:
+		for field, errs := range verr {
+			e.Add(prefix+field, errs...)
+		}
+		//case Error:
+		//	e.Add(prefix+verr.Field(), verr.Errors()...)
+	default:
+		e.Add(prefix+"_", errors)
+	}
+}
+
+func (e Errors) MarshalJSON() ([]byte, error) {
+	//order alphabetic field/namess
+	names := make([]string, 0, len(e))
+	for name := range e {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	for i, name := range names {
+		if i != 0 {
+			buf.WriteByte(',')
+		}
+
+		//name/field who contains errors
+		key, err := json.Marshal(name)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(key)
+
+		buf.WriteString(":[")
+
+		//stringify errors
+		for esi, es := range e[name] {
+			if esi != 0 {
+				buf.WriteByte(',')
+			}
+			val, err := json.Marshal(es.Error())
+			if err != nil {
+				return nil, err
+			}
+			buf.Write(val)
+		}
+		buf.WriteByte(']')
+
+	}
+	buf.WriteString("}")
+	return buf.Bytes(), nil
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,33 @@
+package validate_test
+
+import (
+	"encoding/json"
+	"github.com/mbict/go-validate"
+	. "gopkg.in/check.v1"
+)
+
+type ErrorsSuite struct{}
+
+var _ = Suite(&ErrorsSuite{})
+
+func (vs *ErrorsSuite) TestError(c *C) {
+	var errors validate.Errors
+
+	errors.Add("foo", validate.ErrRequired)
+	errors.Add("bar", validate.ErrEmpty, validate.ErrEmail)
+
+	c.Assert(errors.Error(), Equals, "bar: [value is empty, invalid email], foo: [required]")
+}
+
+func (vs *ErrorsSuite) TestJsonSerialize(c *C) {
+	var errors validate.Errors
+
+	errors.Add("foo", validate.ErrRequired)
+	errors.Add("bar", validate.ErrEmpty, validate.ErrEmail)
+
+	res, err := json.Marshal(errors)
+
+	c.Assert(err, IsNil)
+	c.Assert(string(res), Equals, `{"bar":["value is empty","invalid email"],"foo":["required"]}`)
+
+}

--- a/rules.go
+++ b/rules.go
@@ -1,0 +1,72 @@
+package validate
+
+import (
+	"fmt"
+	"reflect"
+)
+
+type ValidateFunc func(i interface{}) error
+
+type StructRules map[reflect.Type]Rules
+
+type Rules []Rule
+
+type Rule struct {
+	Name       string
+	FieldIndex int
+	IsSlice    bool
+	IsStruct   bool
+	Validators []validatorTag
+	Subset     Rules
+}
+
+func (r *Rules) Validate(value reflect.Value) Errors {
+	var errs Errors
+	for _, rule := range *r {
+		v := value.Field(rule.FieldIndex)
+		if verr := rule.Validate(v); verr != nil {
+			errs.Merge(verr)
+		}
+	}
+
+	// implemented the ValidateInterface
+	if validateFunc, ok := value.Interface().(ValidateInterface); ok {
+		if err := validateFunc.Validate(); err != nil {
+			errs.Merge(err)
+		}
+	}
+
+	return errs
+}
+
+func (r *Rule) Validate(value reflect.Value) Errors {
+	var errs Errors
+
+	i := value.Interface()
+	for _, validator := range r.Validators {
+		if err := validator.Fn(i, validator.Args); err != nil {
+			errs.Add(r.Name, err)
+		}
+	}
+
+	if value.Kind() == reflect.Ptr && value.IsNil() {
+		return errs
+	}
+
+	value = reflect.Indirect(value)
+	if r.IsSlice && r.IsStruct {
+		for i := 0; i < value.Len(); i++ {
+			errv := r.Subset.Validate(reflect.Indirect(value.Index(i)))
+			if errv != nil {
+				errs.MergePrefix(fmt.Sprintf("%s.%d.", r.Name, i), errv)
+			}
+		}
+	} else if r.IsStruct {
+		errv := r.Subset.Validate(value)
+		if errv != nil {
+			errs.MergePrefix(r.Name+".", errv)
+		}
+	}
+
+	return errs
+}

--- a/validator.go
+++ b/validator.go
@@ -1,10 +1,11 @@
 package validate
 
 import (
-	"fmt"
 	"github.com/mbict/go-errors"
 	"github.com/mbict/go-tags"
 	"reflect"
+	"strings"
+	"sync"
 	"unicode"
 )
 
@@ -12,43 +13,83 @@ import (
 type Validator interface {
 	SetTag(tag string)
 	WithTag(tag string) Validator
-	SetValidationFunc(name string, vf ValidationFunc) error
+	SetValidationFunc(name string, vf ValidatorFunc) error
+	SetNameResolver(resolver NameResolverFunc)
 	Validate(v interface{}) error
 	Valid(val interface{}, tags string) error
 }
 
-// tag represents one of the tag items
-type tag struct {
-	tags.Param                // name of the validator and the arguments to send to the validator func
-	Fn         ValidationFunc // validation function to call
+// validatorTag represents one of the validatorTag items
+type validatorTag struct {
+	tags.Param               // name of the validator and the arguments to send to the validator func
+	Fn         ValidatorFunc // validation function to call
 }
 
 // ValidateInterface describes the interface a structure can embed to enable custom validation of the structure
 type ValidateInterface interface {
-	Validate() errors.ErrorHash
+	Validate() error
 }
 
-// ValidationFunc is a function that receives the value of a
-// field and the parameters used for the respective validation tag.
-type ValidationFunc func(v interface{}, params []string) error
+// ValidatorFunc is a function that receives the value of a
+// field and the parameters used for the respective validation validatorTag.
+type ValidatorFunc func(v interface{}, params []string) error
 
 // validator implements the Validator interface
 type validator struct {
-	tagName         string                    // structure tag name being used (`validate`)
-	validationFuncs map[string]ValidationFunc // validator functions map indexed by name
+	tagName         string                   // structure validatorTag name being used (`validate`)
+	validationFuncs map[string]ValidatorFunc // validator functions map indexed by name
+	structRules     StructRules              // structure rules cache
+	mu              sync.RWMutex             // rw mutex for structure rules cache
+	nameResolver    NameResolverFunc         // func to extract the name to use for field error
+}
+
+type NameResolverFunc func(reflect.StructField) string
+
+var DefaultNameResolver = func(field reflect.StructField) string {
+	return field.Name
+}
+
+var JsonNameResolver = func(field reflect.StructField) string {
+	tag := field.Tag.Get("json")
+	props := strings.SplitN(tag, ",", 2)
+	if props[0] == "" {
+		return field.Name
+	}
+	return props[0]
 }
 
 // Helper validator so users can use the
 // functions directly from the package
 var defaultValidator = NewValidator()
 
+type Option func(Validator)
+
+func NameResolverOption(resolver NameResolverFunc) Option {
+	return func(v Validator) {
+		v.SetNameResolver(resolver)
+	}
+}
+
+func TagOption(tag string) Option {
+	return func(v Validator) {
+		v.SetTag(tag)
+	}
+}
+
+func ValidatorOption(name string, validatorFunc ValidatorFunc) Option {
+	return func(v Validator) {
+		v.SetValidationFunc(name, validatorFunc)
+	}
+}
+
 // NewValidator creates a new Validator
-func NewValidator() Validator {
-	return &validator{
+func NewValidator(options ...Option) Validator {
+	v := &validator{
 		tagName: "validate",
-		validationFuncs: map[string]ValidationFunc{
+		validationFuncs: map[string]ValidatorFunc{
 			"omitempty":      omitempty,
 			"required":       required,
+			"not_empty":      notEmpty,
 			"len":            length,
 			"min":            min,
 			"max":            max,
@@ -72,15 +113,23 @@ func NewValidator() Validator {
 			"uuid5":          uuid5,
 			"base64":         base64,
 		},
+		structRules:  make(StructRules),
+		nameResolver: DefaultNameResolver,
 	}
+
+	for _, option := range options {
+		option(v)
+	}
+
+	return v
 }
 
-// SetTag allows you to change the tag name used in structs for the default validator
+// SetTag allows you to change the validatorTag name used in structs for the default validator
 func SetTag(tag string) {
 	defaultValidator.SetTag(tag)
 }
 
-// WithTag creates a new Validator with the new tag name. It will leave
+// WithTag creates a new Validator with the new validatorTag name. It will leave
 // the defaultValidator untouched
 func WithTag(tag string) Validator {
 	return defaultValidator.WithTag(tag)
@@ -90,7 +139,7 @@ func WithTag(tag string) Validator {
 // Calling this function with nil validatorFunction (vf) is the same as removing
 // the constraint function from the list. The function will be added to the default
 // validator
-func SetValidationFunc(name string, vf ValidationFunc) error {
+func SetValidationFunc(name string, vf ValidatorFunc) error {
 	return defaultValidator.SetValidationFunc(name, vf)
 }
 
@@ -105,12 +154,19 @@ func Valid(val interface{}, tags string) error {
 	return defaultValidator.Valid(val, tags)
 }
 
-// SetTag allows you to change the tag name used in structs
-func (mv *validator) SetTag(tag string) {
-	mv.tagName = tag
+// SetNameResolver allows you to change the way field names are resolved
+func (mv *validator) SetNameResolver(resolver NameResolverFunc) {
+	mv.nameResolver = resolver
+	mv.resetCache()
 }
 
-// WithTag creates a new Validator based on the current validator with the new tag name.
+// SetTag allows you to change the validatorTag name used in structs
+func (mv *validator) SetTag(tag string) {
+	mv.tagName = tag
+	mv.resetCache()
+}
+
+// WithTag creates a new Validator based on the current validator with the new validatorTag name.
 func (mv *validator) WithTag(tag string) Validator {
 	v := mv.copy()
 	v.SetTag(tag)
@@ -122,13 +178,15 @@ func (mv *validator) copy() Validator {
 	return &validator{
 		tagName:         mv.tagName,
 		validationFuncs: mv.validationFuncs,
+		structRules:     mv.structRules,
+		nameResolver:    mv.nameResolver,
 	}
 }
 
 // SetValidationFunc sets the function to be used for a given validation constraint.
 // Calling this function with nil validatorFunction (vf) is the same as removing
 // the constraint function from the list.
-func (mv *validator) SetValidationFunc(name string, vf ValidationFunc) error {
+func (mv *validator) SetValidationFunc(name string, vf ValidatorFunc) error {
 	if name == "" {
 		return errors.New("name cannot be empty")
 	}
@@ -145,7 +203,12 @@ func (mv *validator) SetValidationFunc(name string, vf ValidationFunc) error {
 // The returned error is of the type errors.ErrorHash.
 func (mv *validator) Validate(v interface{}) error {
 	sv := reflect.ValueOf(v)
-	st := reflect.TypeOf(v)
+
+	//nil pointer not type found
+	if sv.Kind() == reflect.Invalid {
+		return ErrUnsupported
+	}
+
 	if sv.Kind() == reflect.Ptr && !sv.IsNil() {
 		return mv.Validate(sv.Elem().Interface())
 	}
@@ -154,83 +217,22 @@ func (mv *validator) Validate(v interface{}) error {
 		return ErrUnsupported
 	}
 
-	nfields := sv.NumField()
-	m := make(errors.ErrorHash)
-	for i := 0; i < nfields; i++ {
-		f := sv.Field(i)
-
-		// deal with pointers
-		for f.Kind() == reflect.Ptr && !f.IsNil() {
-			f = f.Elem()
+	mv.mu.RLock()
+	rules, ok := mv.structRules[sv.Type()]
+	mv.mu.RUnlock()
+	if !ok {
+		mv.mu.Lock()
+		defer mv.mu.Unlock()
+		r, err := mv.parseStruct(sv.Type())
+		if err != nil {
+			return err
 		}
-		tag := st.Field(i).Tag.Get(mv.tagName)
-
-		if tag == "-" {
-			continue
-		}
-
-		fname := st.Field(i).Name
-		if !unicode.IsUpper(rune(fname[0])) {
-			continue
-		}
-
-		var errs errors.Errors
-		if tag != "" {
-			err := mv.Valid(f.Interface(), tag)
-			if e, ok := err.(errors.Errors); ok {
-				errs = e
-			} else {
-				if err != nil {
-					errs = errors.Errors{err}
-				}
-			}
-		}
-
-		if f.Kind() == reflect.Slice {
-			t := f.Type().Elem()
-			if t.Kind() == reflect.Ptr {
-				t = t.Elem()
-			}
-
-			if t.Kind() == reflect.Struct {
-				for i := 0; i < f.Len(); i++ {
-					e := mv.Validate(f.Index(i).Interface())
-					if e, ok := e.(errors.ErrorHash); ok && len(e) > 0 {
-						for j, k := range e {
-							field := fmt.Sprintf("%s.%d.%s", fname, i, j)
-							m[field] = k
-						}
-					}
-				}
-			}
-		} else if f.Kind() == reflect.Struct {
-
-			e := mv.Validate(f.Interface())
-			if e, ok := e.(errors.ErrorHash); ok && len(e) > 0 {
-				for j, k := range e {
-					m[fname+"."+j] = k
-				}
-			}
-		}
-
-		if len(errs) > 0 {
-			m[st.Field(i).Name] = errs
-		}
+		mv.structRules[sv.Type()] = r
+		rules = r
 	}
 
-	//structure custom validator function
-	i := sv.Interface()
-	if validateFunc, ok := i.(ValidateInterface); ok {
-		em := validateFunc.Validate()
-		if em != nil && len(em) > 0 {
-			for f, e := range em {
-				m[f] = append(m[f], e...)
-			}
-		}
-	}
-
-	if len(m) > 0 {
-		return m
+	if errs := rules.Validate(sv); len(errs) > 0 {
+		return errs
 	}
 	return nil
 }
@@ -245,24 +247,26 @@ func (mv *validator) Valid(val interface{}, tags string) error {
 		return mv.Valid(v.Elem().Interface(), tags)
 	}
 
-	var err error
-	switch v.Kind() {
-	case reflect.Invalid:
-		err = mv.validateVar(nil, tags)
-	default:
-		err = mv.validateVar(val, tags)
+	if v.Kind() == reflect.Invalid {
+		return mv.validateVar(nil, tags)
 	}
-	return err
+	return mv.validateVar(val, tags)
+}
+
+func (mv *validator) resetCache() {
+	mv.mu.Lock()
+	defer mv.mu.Unlock()
+	mv.structRules = make(StructRules, 0)
 }
 
 // validateVar validates a single variable
 func (mv *validator) validateVar(v interface{}, tag string) error {
 	tags, err := mv.parseTags(tag)
 	if err != nil {
-		// unknown tag found.
+		// unknown validatorTag found.
 		return err
 	}
-	errs := make(errors.Errors, 0, len(tags))
+	var errs ErrorList
 	for _, t := range tags {
 		if err := t.Fn(v, t.Args); err != nil {
 			if err == errOmitEmpty {
@@ -271,31 +275,102 @@ func (mv *validator) validateVar(v interface{}, tag string) error {
 			errs = append(errs, err)
 		}
 	}
-	if len(errs) > 0 {
-		return errs
-	}
-	return nil
+	return errs
 }
 
-// parseTags parses all individual tags found within a struct tag and
+// parseTags parses all individual tags found within a struct validatorTag and
 // resolve the validator function
-func (mv *validator) parseTags(t string) ([]tag, error) {
+func (mv *validator) parseTags(t string) ([]validatorTag, error) {
 	params, err := tags.Parse(t)
 	if err != nil {
 		return nil, ErrSyntax
 	}
 
-	tags := make([]tag, 0, len(params))
+	tags := make([]validatorTag, 0, len(params))
 	for _, param := range params {
 		validatorFunc, found := mv.validationFuncs[param.Name]
 		if !found {
 			return nil, ErrUnknownTag
 		}
 
-		tags = append(tags, tag{
+		tags = append(tags, validatorTag{
 			Param: param,
 			Fn:    validatorFunc,
 		})
 	}
 	return tags, nil
+}
+
+// parseStruct will extract all the validation rules from the given structure
+func (mv *validator) parseStruct(t reflect.Type) (Rules, error) {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	if t.Kind() != reflect.Struct {
+		return nil, ErrUnsupported
+	}
+
+	rules := Rules{}
+	for i := 0; i < t.NumField(); i++ {
+		sf := t.Field(i)
+		tag := sf.Tag.Get(mv.tagName)
+
+		if tag == "-" {
+			continue
+		}
+
+		fieldName := mv.nameResolver(sf)
+		if !unicode.IsUpper(rune(fieldName[0])) {
+			continue
+		}
+
+		rule := Rule{
+			Name:       fieldName,
+			FieldIndex: i,
+			IsSlice:    false,
+			IsStruct:   false,
+		}
+
+		if tag != "" {
+			//extract the validator properties
+			validatorTags, err := mv.parseTags(tag)
+			if err != nil {
+				// unknown validatorTag found.
+				return nil, err
+			}
+
+			//Add validatorTags to rules
+			rule.Validators = validatorTags
+
+		}
+
+		st := sf.Type
+		if st.Kind() == reflect.Slice {
+			rule.IsSlice = true
+			st = st.Elem()
+		}
+
+		if st.Kind() == reflect.Ptr {
+			st = st.Elem()
+		}
+
+		if st.Kind() == reflect.Struct {
+			subset, ok := mv.structRules[st]
+			if !ok {
+				var err error
+				subset, err = mv.parseStruct(st)
+				if err != nil {
+					return nil, err
+				}
+				mv.structRules[st] = subset
+			}
+			rule.IsStruct = true
+			rule.Subset = subset
+		}
+
+		rules = append(rules, rule)
+	}
+
+	return rules, nil
 }

--- a/validator.go
+++ b/validator.go
@@ -21,8 +21,8 @@ type Validator interface {
 
 // validatorTag represents one of the validatorTag items
 type validatorTag struct {
-	tags.Param               // name of the validator and the arguments to send to the validator func
-	Fn         ValidatorFunc // validation function to call
+	tags.Param       // name of the validator and the arguments to send to the validator func
+	Fn ValidatorFunc // validation function to call
 }
 
 // ValidateInterface describes the interface a structure can embed to enable custom validation of the structure
@@ -112,6 +112,7 @@ func NewValidator(options ...Option) Validator {
 			"uuid4":          uuid4,
 			"uuid5":          uuid5,
 			"base64":         base64,
+			"enum":           enum,
 		},
 		structRules:  make(StructRules),
 		nameResolver: DefaultNameResolver,

--- a/validator_test.go
+++ b/validator_test.go
@@ -1,8 +1,7 @@
 package validate_test
 
 import (
-	errors "github.com/mbict/go-errors"
-	validate "github.com/mbict/go-validate"
+	"github.com/mbict/go-validate"
 	. "gopkg.in/check.v1"
 	"testing"
 )
@@ -54,7 +53,8 @@ func (vs *ValidatorSuite) TestValidate(c *C) {
 	err := validate.Validate(test[0])
 	c.Assert(err, NotNil)
 
-	errs, ok := err.(errors.ErrorHash)
+	errs, ok := err.(validate.Errors)
+
 	c.Assert(ok, Equals, true)
 	c.Assert(errs["A"], HasLen, 2)
 	c.Assert(errs["A"], HasError, validate.ErrRequired)
@@ -74,15 +74,21 @@ func (vs *ValidatorSuite) TestValidate(c *C) {
 	err = validate.Validate(test[1])
 	c.Assert(err, NotNil)
 
-	errs, ok = err.(errors.ErrorHash)
+	errs, ok = err.(validate.Errors)
+
 	c.Assert(ok, Equals, true)
+	c.Assert(errs["A"], NotNil)
 	c.Assert(errs["A"], HasLen, 1)
 	c.Assert(errs["A"], HasError, validate.ErrMax)
+	c.Assert(errs["B"], NotNil)
 	c.Assert(errs["B"], HasLen, 1)
 	c.Assert(errs["B"], HasError, validate.ErrMax)
-	c.Assert(errs["C"], HasLen, 1)
-	c.Assert(errs["C"], HasError, validate.ErrRequired)
-	c.Assert(errs["D"], HasLen, 0)
+	c.Assert(errs["C"], IsNil)
+	//c.Assert(errs["C"], NotNil)
+	//c.Assert(errs["C"].Errors(), HasLen, 1)
+	//c.Assert(errs["C"], HasError, validate.ErrRequired)
+	c.Assert(errs["D"], IsNil)
+	c.Assert(errs["E"], NotNil)
 	c.Assert(errs["E"], HasLen, 1)
 	c.Assert(errs["E"], HasError, validate.ErrMax)
 
@@ -111,21 +117,21 @@ func (vs *ValidatorSuite) TestValidateEmbedStruct(c *C) {
 	err := validate.Validate(test[0])
 	c.Assert(err, NotNil)
 
-	errs, ok := err.(errors.ErrorHash)
+	errs, ok := err.(validate.Errors)
 	c.Assert(ok, Equals, true)
 	c.Assert(errs["A.A"], HasLen, 1)
 	c.Assert(errs["A.A"], HasError, validate.ErrMin)
 	c.Assert(errs["B"], HasLen, 1)
 	c.Assert(errs["B"], HasError, validate.ErrRequired)
-	c.Assert(errs["B.A"], HasLen, 0)
+	c.Assert(errs["B.A"], IsNil)
 
 	//error, initialized ptr
 	err = validate.Validate(test[1])
 	c.Assert(err, NotNil)
 
-	errs, ok = err.(errors.ErrorHash)
+	errs, ok = err.(validate.Errors)
 	c.Assert(ok, Equals, true)
-	c.Assert(errs["B"], HasLen, 0)
+	c.Assert(errs["B"], IsNil)
 	c.Assert(errs["B.A"], HasLen, 1)
 	c.Assert(errs["B.A"], HasError, validate.ErrMin)
 
@@ -133,9 +139,9 @@ func (vs *ValidatorSuite) TestValidateEmbedStruct(c *C) {
 	err = validate.Validate(test[1])
 	c.Assert(err, NotNil)
 
-	errs, ok = err.(errors.ErrorHash)
+	errs, ok = err.(validate.Errors)
 	c.Assert(ok, Equals, true)
-	c.Assert(errs["B"], HasLen, 0)
+	c.Assert(errs["B"], IsNil)
 	c.Assert(errs["B.A"], HasLen, 1)
 	c.Assert(errs["B.A"], HasError, validate.ErrMin)
 
@@ -168,7 +174,7 @@ func (vs *ValidatorSuite) TestValidateSlice(c *C) {
 	err := validate.Validate(test[0])
 	c.Assert(err, NotNil)
 
-	errs, ok := err.(errors.ErrorHash)
+	errs, ok := err.(validate.Errors)
 	c.Assert(ok, Equals, true)
 	c.Assert(errs["A"], HasLen, 2)
 	c.Assert(errs["A"], HasError, validate.ErrMin)
@@ -180,7 +186,7 @@ func (vs *ValidatorSuite) TestValidateSlice(c *C) {
 	err = validate.Validate(test[1])
 	c.Assert(err, NotNil)
 
-	errs, ok = err.(errors.ErrorHash)
+	errs, ok = err.(validate.Errors)
 	c.Assert(ok, Equals, true)
 	c.Assert(errs["A"], HasLen, 2)
 	c.Assert(errs["A"], HasError, validate.ErrMin)
@@ -192,14 +198,14 @@ func (vs *ValidatorSuite) TestValidateSlice(c *C) {
 	err = validate.Validate(test[2])
 	c.Assert(err, NotNil)
 
-	errs, ok = err.(errors.ErrorHash)
+	errs, ok = err.(validate.Errors)
 	c.Assert(ok, Equals, true)
 	c.Assert(errs["A"], HasLen, 1)
 	c.Assert(errs["A"], HasError, validate.ErrMin)
 	c.Assert(errs["A.0.A"], HasLen, 1)
 	c.Assert(errs["A.0.A"], HasError, validate.ErrMin)
-	c.Assert(errs["B"], HasLen, 0)
-	c.Assert(errs["B.0.A"], HasLen, 0)
+	c.Assert(errs["B"], IsNil)
+	c.Assert(errs["B.0.A"], IsNil)
 	c.Assert(errs["B.1.A"], HasLen, 1)
 	c.Assert(errs["B.1.A"], HasError, validate.ErrMin)
 
@@ -226,11 +232,11 @@ func (vs *ValidatorSuite) TestValidateIgnoreNonExportedVars(c *C) {
 	err := validate.Validate(test[0])
 	c.Assert(err, NotNil)
 
-	errs, ok := err.(errors.ErrorHash)
+	errs, ok := err.(validate.Errors)
 	c.Assert(ok, Equals, true)
 	c.Assert(errs["A"], HasLen, 1)
 	c.Assert(errs["A"], HasError, validate.ErrRequired)
-	c.Assert(errs["b"], HasLen, 0)
+	c.Assert(errs["b"], IsNil)
 
 	//error, initialized ptr
 	err = validate.Validate(test[1])
@@ -238,12 +244,14 @@ func (vs *ValidatorSuite) TestValidateIgnoreNonExportedVars(c *C) {
 }
 
 func (vs *ValidatorSuite) TestValidateInputNilValue(c *C) {
-	//nil pointer
 	err := validate.Validate(nil)
-	c.Assert(err, Equals, validate.ErrUnsupported)
 
-	//typed nil pointer
-	err = validate.Validate((*testSimple)(nil))
+	c.Assert(err, Equals, validate.ErrUnsupported)
+}
+
+func (vs *ValidatorSuite) TestValidateInputTypedNilValue(c *C) {
+	err := validate.Validate((*testSimple)(nil))
+
 	c.Assert(err, Equals, validate.ErrUnsupported)
 }
 
@@ -281,32 +289,31 @@ type testStructValidateFuncInterface struct {
 	A            int `validate:"min(2)"`
 	B            int `validate:"min(2)"`
 	C            int `validate:"min(10)"`
-	validateFunc func() errors.ErrorHash
+	validateFunc func() error
 }
 
-func (s testStructValidateFuncInterface) Validate() errors.ErrorHash {
+func (s testStructValidateFuncInterface) Validate() error {
 	return s.validateFunc()
 }
 
 func (vs *ValidatorSuite) TestStructValidateInterface(c *C) {
-	customErr1 := errors.New("custom 1")
-	customErr2 := errors.New("cutsom 2")
+	customErr1 := validate.NewValidationError("custom 1")
+	customErr2 := validate.NewValidationError("cutsom 2")
 
 	test := testStructValidateFuncInterface{
 		A: 1,
 		B: 2,
 		C: 3,
-		validateFunc: func() errors.ErrorHash {
-			return errors.ErrorHash{
-				"A": errors.Errors{customErr1, customErr2},
-				"B": errors.Errors{customErr1},
-				"D": errors.Errors{customErr2},
+		validateFunc: func() error {
+			return validate.Errors{
+				"A": validate.ErrorList{customErr1, customErr2},
+				"B": validate.ErrorList{customErr1},
+				"D": validate.ErrorList{customErr2},
 			}
 		},
 	}
 
-	errs := validate.Validate(test).(errors.ErrorHash)
-
+	errs := validate.Validate(test).(validate.Errors)
 	c.Assert(errs, HasLen, 4)
 	c.Assert(errs["A"], HasLen, 3)
 	c.Assert(errs["A"], HasError, validate.ErrMin)
@@ -319,8 +326,7 @@ func (vs *ValidatorSuite) TestStructValidateInterface(c *C) {
 	c.Assert(errs["D"], HasLen, 1)
 	c.Assert(errs["D"], HasError, customErr2)
 
-	errs = validate.Validate(&test).(errors.ErrorHash)
-
+	errs = validate.Validate(&test).(validate.Errors)
 	c.Assert(errs, HasLen, 4)
 	c.Assert(errs["A"], HasLen, 3)
 	c.Assert(errs["A"], HasError, validate.ErrMin)
@@ -339,20 +345,20 @@ func (vs *ValidatorSuite) TestValidMap(c *C) {
 
 	err := validate.Valid(m, "required")
 	c.Assert(err, NotNil)
-	errs, ok := err.(errors.Errors)
+	errs, ok := err.(validate.ErrorList)
 	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasError, validate.ErrRequired)
 
 	err = validate.Valid(m, "min(1)")
 	c.Assert(err, NotNil)
-	errs, ok = err.(errors.Errors)
+	errs, ok = err.(validate.ErrorList)
 	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasError, validate.ErrMin)
 
 	m = map[string]string{"A": "a", "B": "a"}
 	err = validate.Valid(m, "max(1)")
 	c.Assert(err, NotNil)
-	errs, ok = err.(errors.Errors)
+	errs, ok = err.(validate.ErrorList)
 	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasError, validate.ErrMax)
 
@@ -368,7 +374,7 @@ func (vs *ValidatorSuite) TestValidMap(c *C) {
 	}
 	err = validate.Valid(m, "len(4),min(6),max(1),required")
 	c.Assert(err, NotNil)
-	errs, ok = err.(errors.Errors)
+	errs, ok = err.(validate.ErrorList)
 	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasError, validate.ErrLen)
 	c.Assert(errs, HasError, validate.ErrMin)
@@ -383,7 +389,7 @@ func (vs *ValidatorSuite) TestValidFloat(c *C) {
 
 	err = validate.Valid(0.0, "required")
 	c.Assert(err, NotNil)
-	errs, ok := err.(errors.Errors)
+	errs, ok := err.(validate.ErrorList)
 	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasError, validate.ErrRequired)
 }
@@ -398,14 +404,14 @@ func (vs *ValidatorSuite) TestValidInt(c *C) {
 
 	err = validate.Valid(i, "min(124), max(122)")
 	c.Assert(err, NotNil)
-	errs, ok := err.(errors.Errors)
+	errs, ok := err.(validate.ErrorList)
 	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasError, validate.ErrMin)
 	c.Assert(errs, HasError, validate.ErrMax)
 
 	err = validate.Valid(i, "max(10)")
 	c.Assert(err, NotNil)
-	errs, ok = err.(errors.Errors)
+	errs, ok = err.(validate.ErrorList)
 	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasError, validate.ErrMax)
 }
@@ -417,7 +423,7 @@ func (vs *ValidatorSuite) TestValidString(c *C) {
 
 	err = validate.Valid(s, "len(0)")
 	c.Assert(err, NotNil)
-	errs, ok := err.(errors.Errors)
+	errs, ok := err.(validate.ErrorList)
 	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasError, validate.ErrLen)
 
@@ -429,7 +435,7 @@ func (vs *ValidatorSuite) TestValidString(c *C) {
 
 	err = validate.Valid("", `required,len(3),max(1)`)
 	c.Assert(err, NotNil)
-	errs, ok = err.(errors.Errors)
+	errs, ok = err.(validate.ErrorList)
 	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasLen, 2)
 	c.Assert(errs, HasError, validate.ErrRequired)
@@ -444,7 +450,7 @@ func (vs *ValidatorSuite) TestValidPtr(c *C) {
 
 	err = validate.Valid(&s, "len(0)")
 	c.Assert(err, NotNil)
-	errs, ok := err.(errors.Errors)
+	errs, ok := err.(validate.ErrorList)
 	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasError, validate.ErrLen)
 }
@@ -467,7 +473,7 @@ func (vs *ValidatorSuite) TestValidateWithCustomValidator(c *C) {
 
 	err = validator.Valid("foo", `equals("bar")`)
 	c.Assert(err, NotNil)
-	errs, ok := err.(errors.Errors)
+	errs, ok := err.(validate.ErrorList)
 	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasError, validate.ErrInvalid)
 }
@@ -504,7 +510,7 @@ func (vs *ValidatorSuite) TestValidateWithTag(c *C) {
 	err := validator.Validate(test)
 	c.Assert(err, NotNil)
 
-	errs, ok := err.(errors.ErrorHash)
+	errs, ok := err.(validate.Errors)
 	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasLen, 1)
 	c.Assert(errs["A"], HasLen, 1)
@@ -522,7 +528,7 @@ func (vs *ValidatorSuite) TestValidateSetTag(c *C) {
 	err := validator.Validate(test)
 	c.Assert(err, NotNil)
 
-	errs, ok := err.(errors.ErrorHash)
+	errs, ok := err.(validate.Errors)
 	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasLen, 1)
 	c.Assert(errs["A"], HasLen, 1)
@@ -533,7 +539,7 @@ type testSimpleValidateEmbed struct {
 	A int `validate:"min(10)"`
 }
 
-func (t *testSimpleValidateEmbed) Validate() errors.ErrorHash {
+func (t *testSimpleValidateEmbed) Validate() validate.Errors {
 	return nil
 }
 
@@ -547,10 +553,15 @@ func (c *hasErrorChecker) Check(params []interface{}, names []string) (bool, str
 		slice []error
 		value error
 	)
-	slice, ok = params[0].(errors.Errors)
-	if !ok {
-		return false, "First parameter is not an Errorarray"
+
+	if e, ok := params[0].([]error); ok {
+		slice = e
+	} else if e, ok := params[0].(validate.ErrorList); ok {
+		slice = e
+	} else {
+		return false, "First parameter is not an Errors"
 	}
+
 	value, ok = params[1].(error)
 	if !ok {
 		return false, "Second parameter is not an error"


### PR DESCRIPTION
…e and made validate package responsible for that, added options in validator constructor, the way of resolving the names of the fields is now configurable. By default there are 2 ways provided json name or the structure name. ValidateInterface changed signature breaking backwards compatibility.